### PR TITLE
feat: leaf circuit

### DIFF
--- a/circuit/src/inputs.rs
+++ b/circuit/src/inputs.rs
@@ -49,7 +49,7 @@ impl TryFrom<ProofWithPublicInputs<F, C, D>> for PublicCircuitInputs {
 
         // TODO: Create constants for the indices where each field is expected in the public
         // inputs.
-        let funding_amount = felts_to_u128(public_inputs[0..2].to_vec());
+        let funding_amount = felts_to_u128(public_inputs[0..2].try_into()?);
         let nullifier = Nullifier::from_field_elements(&public_inputs[2..6])?;
 
         let root_hash: [u8; 32] = felts_to_bytes(&public_inputs[6..10])

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -9,10 +9,10 @@ use plonky2::{
 };
 
 use crate::circuit::{CircuitFragment, D, F};
+use crate::utils::u128_to_felts;
 use crate::{codec::FieldElementCodec, utils::bytes_to_felts};
 use crate::{gadgets::is_const_less_than, substrate_account::SubstrateAccount};
 use crate::{inputs::CircuitInputs, unspendable_account::UnspendableAccount};
-use crate::utils::u128_to_felts;
 
 pub const MAX_PROOF_LEN: usize = 20;
 pub const PROOF_NODE_MAX_SIZE_F: usize = 73;
@@ -58,7 +58,7 @@ pub struct LeafInputs {
     nonce: F,
     funding_account: SubstrateAccount,
     to_account: UnspendableAccount,
-    funding_amount: Vec<F>, // 2 since balances are u128
+    funding_amount: [F; 2], // 2 since balances are u128
 }
 
 impl LeafInputs {
@@ -232,9 +232,9 @@ fn slice_to_hashout(slice: &[u8]) -> HashOut<F> {
 pub mod test_helpers {
     use plonky2::field::types::Field;
 
+    use super::{LeafInputs, StorageProof};
     use crate::circuit::F;
     use crate::utils::u128_to_felts;
-    use super::{LeafInputs, StorageProof};
 
     pub const ROOT_HASH: &str = "77eb9d80cd12acfd902b459eb3b8876f05f31ef6a17ed5fdb060ee0e86dd8139";
     pub const STORAGE_PROOF: [(&str, &str); 3] = [

--- a/circuit/src/storage_proof.rs
+++ b/circuit/src/storage_proof.rs
@@ -66,7 +66,7 @@ impl LeafInputs {
         nonce: F,
         funding_account: SubstrateAccount,
         to_account: UnspendableAccount,
-        funding_amount: F,
+        funding_amount: [F; 2],
     ) -> Self {
         Self {
             nonce,

--- a/circuit/src/test_helpers.rs
+++ b/circuit/src/test_helpers.rs
@@ -79,7 +79,7 @@ pub mod storage_proof {
                 F::from_canonical_u32(1),
                 Default::default(),
                 Default::default(),
-                F::from_noncanonical_u128(0),
+                [F::from_noncanonical_u64(0), F::from_noncanonical_u64(1)],
             )
         }
     }

--- a/circuit/src/test_helpers.rs
+++ b/circuit/src/test_helpers.rs
@@ -38,7 +38,12 @@ impl CircuitInputs {
 }
 
 pub mod storage_proof {
-    use crate::storage_proof::StorageProof;
+    use plonky2::field::types::Field;
+
+    use crate::{
+        circuit::F,
+        storage_proof::{LeafInputs, StorageProof},
+    };
 
     pub const DEFAULT_ROOT_HASH: &str =
         "77eb9d80cd12acfd902b459eb3b8876f05f31ef6a17ed5fdb060ee0e86dd8139";
@@ -59,7 +64,23 @@ pub mod storage_proof {
 
     impl StorageProof {
         pub fn test_inputs() -> Self {
-            StorageProof::new(&default_storage_proof(), default_root_hash())
+            StorageProof::new(
+                &default_storage_proof(),
+                default_root_hash(),
+                LeafInputs::test_inputs(),
+            )
+        }
+    }
+
+    // TODO: Get real inputs from the node.
+    impl LeafInputs {
+        pub fn test_inputs() -> Self {
+            Self::new(
+                F::from_canonical_u32(1),
+                Default::default(),
+                Default::default(),
+                F::from_noncanonical_u128(0),
+            )
         }
     }
 

--- a/circuit/src/utils.rs
+++ b/circuit/src/utils.rs
@@ -3,19 +3,18 @@ use plonky2::field::types::{Field, PrimeField64};
 
 pub const BYTES_PER_ELEMENT: usize = 8;
 
-pub fn u128_to_felts(num: u128) -> Vec<F> {
-    let mut amount_felts: Vec<F> = Vec::with_capacity(2);
-    let amount_high = F::from_noncanonical_u64((num >> 64) as u64);
-    let amount_low = F::from_noncanonical_u64(num as u64);
-    amount_felts.push(amount_high);
-    amount_felts.push(amount_low);
-    amount_felts
+// TODO: A conversion function that's generic over input length.
+pub fn u128_to_felts(num: u128) -> [F; 2] {
+    let mut felts = [F::ZERO; 2];
+    felts[0] = F::from_noncanonical_u64((num >> 64) as u64);
+    felts[1] = F::from_noncanonical_u64(num as u64);
+    felts
 }
 
-pub fn felts_to_u128(felts: Vec<F>) -> u128 {
-    let amount_high: u128 = felts[0].0 as u128;
-    let amount_low: u128 = felts[1].0 as u128;
-    (amount_high << 64) | amount_low
+pub fn felts_to_u128(felts: [F; 2]) -> u128 {
+    let high: u128 = felts[0].0 as u128;
+    let low: u128 = felts[1].0 as u128;
+    (high << 64) | low
 }
 
 // Encodes an 8-byte string into a single field element
@@ -106,7 +105,7 @@ mod tests {
             assert_eq!(felts.len(), 2, "Expected exactly two field elements");
 
             // Vec<F> -> u128
-            let round_trip_num = felts_to_u128(felts.clone());
+            let round_trip_num = felts_to_u128(felts);
 
             // Check that the high and low parts match
             let expected_high = (num >> 64) as u64;
@@ -133,10 +132,10 @@ mod tests {
         ];
 
         for (high, low) in test_cases {
-            let felts = vec![high, low];
+            let felts = [high, low];
 
             // Vec<F> -> u128
-            let num = felts_to_u128(felts.clone());
+            let num = felts_to_u128(felts);
 
             // u128 -> Vec<F>
             let round_trip_felts = u128_to_felts(num);
@@ -163,7 +162,7 @@ mod tests {
         // Test zero
         let num = 0u128;
         let felts = u128_to_felts(num);
-        assert_eq!(felts, vec![f(0), f(0)]);
+        assert_eq!(felts, [f(0), f(0)]);
         let result = felts_to_u128(felts);
         assert_eq!(result, 0);
     }

--- a/circuit/src/utils.rs
+++ b/circuit/src/utils.rs
@@ -1,5 +1,7 @@
-use crate::circuit::F;
+use crate::circuit::{Digest, F};
 use plonky2::field::types::{Field, PrimeField64};
+
+pub const BYTES_PER_ELEMENT: usize = 8;
 
 pub fn u128_to_felts(num: u128) -> Vec<F> {
     let mut amount_felts: Vec<F> = Vec::with_capacity(2);
@@ -30,8 +32,6 @@ pub fn string_to_felt(input: &str) -> F {
 
 /// Converts a given slice into its field element representation.
 pub fn bytes_to_felts(input: &[u8]) -> Vec<F> {
-    const BYTES_PER_ELEMENT: usize = 8;
-
     let mut field_elements: Vec<F> = Vec::new();
     for chunk in input.chunks(BYTES_PER_ELEMENT) {
         let mut bytes = [0u8; 8];
@@ -43,6 +43,25 @@ pub fn bytes_to_felts(input: &[u8]) -> Vec<F> {
     }
 
     field_elements
+}
+
+/// Convert an array of bytes into a [`Digest`].
+pub fn bytes_to_digest(input: [u8; BYTES_PER_ELEMENT * 4]) -> Digest {
+    let mut result = [F::ZERO; 4];
+
+    for (i, f) in result.iter_mut().enumerate() {
+        let start = i * BYTES_PER_ELEMENT;
+        let end = start + BYTES_PER_ELEMENT;
+        let chunk = &input[start..end];
+
+        let mut bytes = [0u8; 8];
+        bytes[..chunk.len()].copy_from_slice(chunk);
+
+        let value = u64::from_le_bytes(bytes);
+        *f = F::from_noncanonical_u64(value);
+    }
+
+    result
 }
 
 /// Converts a given field element slice into its byte representation.


### PR DESCRIPTION
Adds a new circuit to the storage proof circuit, verifying that the leaf node in the proof is the same as the one that can be calculated by `H(nonce | funding_account | to_account | funding_amount)`.
- [x] Add a new circuit.
- [ ] Generate new test inputs.
- [x] Create tests for new circuit.