### PR TITLE
chore: don't store field elements in circuit inputs

### DIFF
--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -71,3 +71,40 @@ pub fn felts_to_bytes(input: &[F]) -> Vec<u8> {
 pub fn felts_to_hashout(felts: &[F; 4]) -> HashOut<F> {
     HashOut { elements: *felts }
 }
+
+/// Converts a given fixed field element array into its byte representation.
+/// - `N` is the size of the input field element array.
+/// - `M` is the size of the output array
+pub fn fixed_felts_to_bytes<const N: usize, const M: usize>(input: [F; N]) -> [u8; M] {
+    let mut bytes = [0u8; M];
+
+    for (i, felt) in input.iter().enumerate() {
+        let start_index = i * BYTES_PER_ELEMENT;
+        let end_index = start_index + BYTES_PER_ELEMENT;
+
+        let value = felt.to_noncanonical_u64();
+        let value_bytes = value.to_be_bytes();
+
+        bytes[start_index..end_index].copy_from_slice(&value_bytes);
+    }
+
+    bytes
+}
+
+/// Converts a given fixed field byte array into its field element representation.
+/// - `N` is the size of the input byte element array.
+/// - `M` is the size of the output array
+pub fn fixed_bytes_to_felts<const N: usize, const M: usize>(input: [u8; N]) -> [F; M] {
+    let mut field_elements = [F::ZERO; M];
+
+    for (i, chunk) in input.chunks(BYTES_PER_ELEMENT).enumerate() {
+        let mut bytes = [0u8; 8];
+        bytes[..chunk.len()].copy_from_slice(chunk);
+        // Convert the chunk to a field element.
+        let value = u64::from_le_bytes(bytes);
+        let field_element = F::from_noncanonical_u64(value);
+        field_elements[i] = field_element;
+    }
+
+    field_elements
+}

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -181,11 +181,10 @@ impl FieldElementCodec for Nullifier {
 
 impl From<&CircuitInputs> for Nullifier {
     fn from(inputs: &CircuitInputs) -> Self {
-        let funding_account = inputs.private.funding_account.to_bytes();
         Self::new(
             &inputs.private.secret,
             inputs.private.funding_nonce,
-            &funding_account,
+            inputs.private.funding_account.as_slice(),
         )
     }
 }

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -5,6 +5,7 @@ use std::vec::Vec;
 
 use crate::codec::ByteCodec;
 use crate::codec::FieldElementCodec;
+use crate::inputs::CircuitInputs;
 use plonky2::field::types::Field;
 use plonky2::{
     hash::{hash_types::HashOutTarget, poseidon::PoseidonHash},
@@ -27,7 +28,6 @@ pub const NULLIFIER_SIZE_FELTS: usize = 4 + 4 + 1 + 4;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Nullifier {
-    // FIXME: Should not be public, remove once hash is precomputed in tests.
     pub hash: Digest,
     pub secret: Vec<F>,
     funding_nonce: F,
@@ -176,6 +176,17 @@ impl FieldElementCodec for Nullifier {
             funding_nonce,
             funding_account,
         })
+    }
+}
+
+impl From<&CircuitInputs> for Nullifier {
+    fn from(inputs: &CircuitInputs) -> Self {
+        let funding_account = inputs.private.funding_account.to_bytes();
+        Self::new(
+            &inputs.private.secret,
+            inputs.private.funding_nonce,
+            &funding_account,
+        )
     }
 }
 

--- a/wormhole/circuit/src/storage_proof/mod.rs
+++ b/wormhole/circuit/src/storage_proof/mod.rs
@@ -124,13 +124,15 @@ impl StorageProof {
     }
 }
 
-impl From<&CircuitInputs> for StorageProof {
-    fn from(inputs: &CircuitInputs) -> Self {
-        Self::new(
+impl TryFrom<&CircuitInputs> for StorageProof {
+    type Error = anyhow::Error;
+
+    fn try_from(inputs: &CircuitInputs) -> Result<Self, Self::Error> {
+        Ok(Self::new(
             &inputs.private.storage_proof,
-            inputs.public.root_hash,
-            LeafInputs::from(inputs),
-        )
+            *inputs.public.root_hash,
+            LeafInputs::try_from(inputs)?,
+        ))
     }
 }
 

--- a/wormhole/circuit/src/substrate_account.rs
+++ b/wormhole/circuit/src/substrate_account.rs
@@ -1,16 +1,22 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::ops::Deref;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
-use crate::codec::{ByteCodec, FieldElementCodec};
+use crate::{
+    codec::{ByteCodec, FieldElementCodec},
+    inputs::{BytesDigest, CircuitInputs},
+};
 use plonky2::{
     hash::hash_types::HashOutTarget,
     iop::witness::{PartialWitness, WitnessWrite},
     plonk::circuit_builder::CircuitBuilder,
 };
-use zk_circuits_common::circuit::{CircuitFragment, D, F};
-use zk_circuits_common::utils::{bytes_to_felts, felts_to_bytes, Digest};
+use zk_circuits_common::utils::{bytes_to_felts, felts_to_bytes, fixed_bytes_to_felts, Digest};
+use zk_circuits_common::{
+    circuit::{CircuitFragment, D, F},
+};
 
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub struct SubstrateAccount(pub Digest);
@@ -50,6 +56,29 @@ impl FieldElementCodec for SubstrateAccount {
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to convert slice to [GoldilocksField; 4]"))?;
         Ok(Self(account_id))
+    }
+}
+
+impl Deref for SubstrateAccount {
+    type Target = Digest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<BytesDigest> for SubstrateAccount {
+    fn from(value: BytesDigest) -> Self {
+        let felts = fixed_bytes_to_felts(*value);
+        SubstrateAccount(felts)
+    }
+}
+
+impl TryFrom<&CircuitInputs> for SubstrateAccount {
+    type Error = anyhow::Error;
+
+    fn try_from(inputs: &CircuitInputs) -> Result<Self, Self::Error> {
+        Self::from_bytes(inputs.public.exit_account.as_slice())
     }
 }
 

--- a/wormhole/circuit/src/substrate_account.rs
+++ b/wormhole/circuit/src/substrate_account.rs
@@ -13,10 +13,8 @@ use plonky2::{
     iop::witness::{PartialWitness, WitnessWrite},
     plonk::circuit_builder::CircuitBuilder,
 };
+use zk_circuits_common::circuit::{CircuitFragment, D, F};
 use zk_circuits_common::utils::{bytes_to_felts, felts_to_bytes, fixed_bytes_to_felts, Digest};
-use zk_circuits_common::{
-    circuit::{CircuitFragment, D, F},
-};
 
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub struct SubstrateAccount(pub Digest);

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -12,8 +12,8 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::Hasher},
 };
 
-use crate::codec::ByteCodec;
 use crate::codec::FieldElementCodec;
+use crate::{codec::ByteCodec, inputs::CircuitInputs};
 use zk_circuits_common::circuit::{CircuitFragment, D, F};
 use zk_circuits_common::utils::{bytes_to_felts, felts_to_bytes, string_to_felt, Digest};
 
@@ -136,6 +136,12 @@ impl FieldElementCodec for UnspendableAccount {
         let secret = elements[offset..offset + secret_size].to_vec();
 
         Ok(Self { account_id, secret })
+    }
+}
+
+impl From<&CircuitInputs> for UnspendableAccount {
+    fn from(inputs: &CircuitInputs) -> Self {
+        Self::new(&inputs.private.secret)
     }
 }
 

--- a/wormhole/prover/src/lib.rs
+++ b/wormhole/prover/src/lib.rs
@@ -26,15 +26,15 @@
 //!     private: PrivateCircuitInputs {
 //!         secret: vec![1u8; 32],
 //!         funding_nonce: 0,
-//!         funding_account: SubstrateAccount::new(&[2u8; 32])?,
+//!         funding_account: [2u8; 32].into(),
 //!         storage_proof: ProcessedStorageProof::new(vec![], vec![]).unwrap(),
-//!         unspendable_account: UnspendableAccount::new(&[1u8; 32]),
+//!         unspendable_account: [1u8; 32].into(),
 //!     },
 //!     public: PublicCircuitInputs {
 //!         funding_amount: 1000,
-//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]).hash,
-//!         root_hash: [0u8; 32],
-//!         exit_account: SubstrateAccount::new(&[2u8; 32])?,
+//!         nullifier: [1u8; 32].into(),
+//!         root_hash: [0u8; 32].into(),
+//!         exit_account: [2u8; 32].into(),
 //!     },
 //! };
 //!
@@ -53,9 +53,11 @@ use plonky2::{
     },
 };
 
-use wormhole_circuit::storage_proof::StorageProof;
-use wormhole_circuit::{circuit::CircuitTargets, inputs::CircuitInputs};
+use wormhole_circuit::{
+    circuit::CircuitTargets, inputs::CircuitInputs, substrate_account::SubstrateAccount,
+};
 use wormhole_circuit::{circuit::WormholeCircuit, nullifier::Nullifier};
+use wormhole_circuit::{storage_proof::StorageProof, unspendable_account::UnspendableAccount};
 use zk_circuits_common::circuit::{CircuitFragment, C, D, F};
 
 #[derive(Debug)]
@@ -106,19 +108,16 @@ impl WormholeProver {
         let Some(targets) = self.targets.take() else {
             bail!("prover has already commited to inputs");
         };
+
         let nullifier = Nullifier::from(circuit_inputs);
-        let storage_proof = StorageProof::from(circuit_inputs);
+        let storage_proof = StorageProof::try_from(circuit_inputs)?;
+        let unspendable_account = UnspendableAccount::from(circuit_inputs);
+        let exit_account = SubstrateAccount::try_from(circuit_inputs)?;
 
         nullifier.fill_targets(&mut self.partial_witness, targets.nullifier)?;
-        circuit_inputs
-            .private
-            .unspendable_account
-            .fill_targets(&mut self.partial_witness, targets.unspendable_account)?;
+        unspendable_account.fill_targets(&mut self.partial_witness, targets.unspendable_account)?;
         storage_proof.fill_targets(&mut self.partial_witness, targets.storage_proof)?;
-        circuit_inputs
-            .public
-            .exit_account
-            .fill_targets(&mut self.partial_witness, targets.exit_account)?;
+        exit_account.fill_targets(&mut self.partial_witness, targets.exit_account)?;
 
         Ok(self)
     }

--- a/wormhole/prover/src/lib.rs
+++ b/wormhole/prover/src/lib.rs
@@ -32,7 +32,7 @@
 //!     },
 //!     public: PublicCircuitInputs {
 //!         funding_amount: 1000,
-//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]),
+//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]).hash,
 //!         root_hash: [0u8; 32],
 //!         exit_account: SubstrateAccount::new(&[2u8; 32])?,
 //!     },
@@ -53,9 +53,9 @@ use plonky2::{
     },
 };
 
-use wormhole_circuit::circuit::WormholeCircuit;
 use wormhole_circuit::storage_proof::StorageProof;
 use wormhole_circuit::{circuit::CircuitTargets, inputs::CircuitInputs};
+use wormhole_circuit::{circuit::WormholeCircuit, nullifier::Nullifier};
 use zk_circuits_common::circuit::{CircuitFragment, C, D, F};
 
 #[derive(Debug)]
@@ -106,12 +106,10 @@ impl WormholeProver {
         let Some(targets) = self.targets.take() else {
             bail!("prover has already commited to inputs");
         };
+        let nullifier = Nullifier::from(circuit_inputs);
         let storage_proof = StorageProof::from(circuit_inputs);
 
-        circuit_inputs
-            .public
-            .nullifier
-            .fill_targets(&mut self.partial_witness, targets.nullifier)?;
+        nullifier.fill_targets(&mut self.partial_witness, targets.nullifier)?;
         circuit_inputs
             .private
             .unspendable_account

--- a/wormhole/tests/test-helpers/src/lib.rs
+++ b/wormhole/tests/test-helpers/src/lib.rs
@@ -1,9 +1,8 @@
 use crate::storage_proof::{DEFAULT_ROOT_HASH, TestInputs};
 use wormhole_circuit::{
-    inputs::{CircuitInputs, PrivateCircuitInputs, PublicCircuitInputs},
+    inputs::{BytesDigest, CircuitInputs, PrivateCircuitInputs, PublicCircuitInputs},
     nullifier::Nullifier,
     storage_proof::ProcessedStorageProof,
-    substrate_account::SubstrateAccount,
     unspendable_account::UnspendableAccount,
 };
 
@@ -23,16 +22,19 @@ pub const DEFAULT_TO_ACCOUNT: [u8; 32] = [
 impl TestInputs for CircuitInputs {
     fn test_inputs() -> Self {
         let secret = hex::decode(DEFAULT_SECRET.trim()).unwrap();
-        let root_hash: [u8; 32] = hex::decode(DEFAULT_ROOT_HASH.trim())
+        let root_hash = hex::decode(DEFAULT_ROOT_HASH.trim())
             .unwrap()
+            .as_slice()
             .try_into()
             .unwrap();
 
-        let funding_account = SubstrateAccount::new(&DEFAULT_FUNDING_ACCOUNT).unwrap();
-        let nullifier =
-            Nullifier::new(&secret, DEFAULT_FUNDING_NONCE, &DEFAULT_FUNDING_ACCOUNT).hash;
-        let unspendable_account = UnspendableAccount::new(&secret);
-        let exit_account = SubstrateAccount::new(&DEFAULT_TO_ACCOUNT).unwrap();
+        let funding_account = BytesDigest::from(DEFAULT_FUNDING_ACCOUNT);
+        let nullifier = Nullifier::new(&secret, DEFAULT_FUNDING_NONCE, &DEFAULT_FUNDING_ACCOUNT)
+            .hash
+            .into();
+        let unspendable_account = UnspendableAccount::new(&secret).account_id.into();
+        let exit_account = BytesDigest::from(DEFAULT_TO_ACCOUNT);
+
         let storage_proof = ProcessedStorageProof::test_inputs();
         Self {
             public: PublicCircuitInputs {
@@ -54,8 +56,8 @@ impl TestInputs for CircuitInputs {
 
 pub mod storage_proof {
     use wormhole_circuit::{
+        inputs::BytesDigest,
         storage_proof::{ProcessedStorageProof, StorageProof, leaf::LeafInputs},
-        substrate_account::SubstrateAccount,
     };
 
     use crate::{
@@ -90,14 +92,15 @@ pub mod storage_proof {
 
     impl TestInputs for LeafInputs {
         fn test_inputs() -> Self {
-            let funding_account = SubstrateAccount::new(&DEFAULT_FUNDING_ACCOUNT).unwrap();
-            let to_account = SubstrateAccount::new(&DEFAULT_TO_ACCOUNT).unwrap();
+            let funding_account = BytesDigest::from(DEFAULT_FUNDING_ACCOUNT);
+            let to_account = BytesDigest::from(DEFAULT_TO_ACCOUNT);
             LeafInputs::new(
                 DEFAULT_FUNDING_NONCE,
                 funding_account,
                 to_account,
                 DEFAULT_FUNDING_AMOUNT,
             )
+            .unwrap()
         }
     }
 

--- a/wormhole/tests/test-helpers/src/lib.rs
+++ b/wormhole/tests/test-helpers/src/lib.rs
@@ -29,7 +29,8 @@ impl TestInputs for CircuitInputs {
             .unwrap();
 
         let funding_account = SubstrateAccount::new(&DEFAULT_FUNDING_ACCOUNT).unwrap();
-        let nullifier = Nullifier::new(&secret, DEFAULT_FUNDING_NONCE, &DEFAULT_FUNDING_ACCOUNT);
+        let nullifier =
+            Nullifier::new(&secret, DEFAULT_FUNDING_NONCE, &DEFAULT_FUNDING_ACCOUNT).hash;
         let unspendable_account = UnspendableAccount::new(&secret);
         let exit_account = SubstrateAccount::new(&DEFAULT_TO_ACCOUNT).unwrap();
         let storage_proof = ProcessedStorageProof::test_inputs();

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -34,7 +34,7 @@
 //!     },
 //!     public: PublicCircuitInputs {
 //!         funding_amount: 1000,
-//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]),
+//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]).hash,
 //!         root_hash: [0u8; 32],
 //!         exit_account: SubstrateAccount::new(&[2u8; 32])?,
 //!     },

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -28,15 +28,15 @@
 //!     private: PrivateCircuitInputs {
 //!         secret: vec![1u8; 32],
 //!         funding_nonce: 0,
-//!         funding_account: SubstrateAccount::new(&[2u8; 32])?,
+//!         funding_account: [2u8; 32].into(),
 //!         storage_proof: ProcessedStorageProof::new(vec![], vec![]).unwrap(),
-//!         unspendable_account: UnspendableAccount::new(&[1u8; 32]),
+//!         unspendable_account: [1u8; 32].into(),
 //!     },
 //!     public: PublicCircuitInputs {
 //!         funding_amount: 1000,
-//!         nullifier: Nullifier::new(&[1u8; 32], 0, &[2u8; 32]).hash,
-//!         root_hash: [0u8; 32],
-//!         exit_account: SubstrateAccount::new(&[2u8; 32])?,
+//!         nullifier: [1u8; 32].into(),
+//!         root_hash: [0u8; 32].into(),
+//!         exit_account: [2u8; 32].into(),
 //!     },
 //! };
 //!


### PR DESCRIPTION
Current version mixes between storing field elements and bytes. This PR addresses that and unifies the circuit inputs to only store bytes, delegating all conversion to the circuit.