### PR TITLE
feat: aggregator from verifier data

### DIFF
--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -18,12 +18,26 @@ pub struct WormholeProofAggregator {
 impl Default for WormholeProofAggregator {
     fn default() -> Self {
         let circuit_config = CircuitConfig::standard_recursion_zk_config();
-        Self::new(circuit_config)
+        Self::from_circuit_config(circuit_config)
     }
 }
 
 impl WormholeProofAggregator {
-    pub fn new(circuit_config: CircuitConfig) -> Self {
+    /// Creates a new [`WormholeProofAggregator`] with a given [`VerifierCircuitData`].
+    pub fn new(verifier_circuit_data: VerifierCircuitData<F, C, D>) -> Self {
+        let aggregation_config = TreeAggregationConfig::default();
+        let proofs_buffer = Some(Vec::with_capacity(aggregation_config.num_leaf_proofs));
+
+        Self {
+            leaf_circuit_data: verifier_circuit_data,
+            config: aggregation_config,
+            proofs_buffer,
+        }
+    }
+
+    /// Creates a new [`WormholeProofAggregator`] with a given [`CircuitConfig`]
+    /// by compiling the circuit data from a [`WormholeVerifier`].
+    pub fn from_circuit_config(circuit_config: CircuitConfig) -> Self {
         let leaf_circuit_data = WormholeVerifier::new(circuit_config.clone(), None).circuit_data;
         let aggregation_config = TreeAggregationConfig::default();
         let proofs_buffer = Some(Vec::with_capacity(aggregation_config.num_leaf_proofs));

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -13,7 +13,7 @@ fn push_proof_to_buffer() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator = WormholeProofAggregator::from_circuit_config(circuit_config());
     aggregator.push_proof(proof).unwrap();
 
     let proofs_buffer = aggregator.proofs_buffer.unwrap();
@@ -27,7 +27,7 @@ fn push_proof_to_full_buffer() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator = WormholeProofAggregator::from_circuit_config(circuit_config());
 
     // Fill up the proof buffer.
     for _ in 0..aggregator.config.num_leaf_proofs {
@@ -48,7 +48,7 @@ fn aggregate_single_proof() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator = WormholeProofAggregator::from_circuit_config(circuit_config());
     aggregator.push_proof(proof).unwrap();
 
     aggregator.aggregate().unwrap();
@@ -61,7 +61,7 @@ fn aggregate_proofs_into_tree() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator = WormholeProofAggregator::from_circuit_config(circuit_config());
 
     // Fill up the proof buffer.
     for _ in 0..aggregator.config.num_leaf_proofs {
@@ -82,7 +82,7 @@ fn aggregate_half_full_proof_array_into_tree() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator = WormholeProofAggregator::from_circuit_config(circuit_config());
 
     // Fill up the proof buffer.
     for _ in 0..aggregator.config.num_leaf_proofs {


### PR DESCRIPTION
Adds a new function for initializing aggregators using verifier circuit data instead of compiling it manually each time.