### PR TITLE
fix: only costruct hashes in tests

### DIFF
--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -83,7 +83,7 @@ pub fn fixed_felts_to_bytes<const N: usize, const M: usize>(input: [F; N]) -> [u
         let end_index = start_index + BYTES_PER_ELEMENT;
 
         let value = felt.to_noncanonical_u64();
-        let value_bytes = value.to_be_bytes();
+        let value_bytes = value.to_le_bytes();
 
         bytes[start_index..end_index].copy_from_slice(&value_bytes);
     }

--- a/wormhole/tests/src/circuit/nullifier_tests.rs
+++ b/wormhole/tests/src/circuit/nullifier_tests.rs
@@ -24,7 +24,7 @@ pub trait TestInputs {
 impl TestInputs for Nullifier {
     fn test_inputs() -> Self {
         let secret = hex::decode(DEFAULT_SECRET).unwrap();
-        Self::new(&secret, DEFAULT_TRANSFER_COUNT)
+        Self::from_preimage(&secret, DEFAULT_TRANSFER_COUNT)
     }
 }
 
@@ -50,14 +50,14 @@ fn invalid_secret_fails_proof() {
 #[test]
 fn all_zero_preimage_is_valid_and_hashes() {
     let preimage_bytes = vec![0u8; 64];
-    let nullifier = Nullifier::new(&preimage_bytes, DEFAULT_TRANSFER_COUNT);
+    let nullifier = Nullifier::from_preimage(&preimage_bytes, DEFAULT_TRANSFER_COUNT);
     let field_elements = nullifier.to_field_elements();
     assert!(!field_elements.iter().all(Field::is_zero));
 }
 
 #[test]
 fn nullifier_codec() {
-    let nullifier = Nullifier::new(&[1u8; 32], DEFAULT_TRANSFER_COUNT);
+    let nullifier = Nullifier::from_preimage(&[1u8; 32], DEFAULT_TRANSFER_COUNT);
 
     // Encode the account as field elements and compare.
     let field_elements = nullifier.to_field_elements();

--- a/wormhole/tests/src/circuit/unspendable_account_tests.rs
+++ b/wormhole/tests/src/circuit/unspendable_account_tests.rs
@@ -46,7 +46,7 @@ fn preimage_matches_right_address() {
     for (secret, address) in SECRETS.iter().zip(ADDRESSES) {
         let decoded_secret = hex::decode(secret).unwrap();
         let decoded_address = hex::decode(address).unwrap();
-        let unspendable_account = UnspendableAccount::new(&decoded_secret);
+        let unspendable_account = UnspendableAccount::from_secret(&decoded_secret);
 
         let address = zk_circuits_common::utils::bytes_to_felts(&decoded_address);
         assert_eq!(unspendable_account.account_id.to_vec(), address);
@@ -59,7 +59,7 @@ fn preimage_matches_right_address() {
 fn preimage_does_not_match_wrong_address() {
     let (secret, wrong_address) = (SECRETS[0], ADDRESSES[1]);
     let decoded_secret = hex::decode(secret).unwrap();
-    let mut unspendable_account = UnspendableAccount::new(&decoded_secret);
+    let mut unspendable_account = UnspendableAccount::from_secret(&decoded_secret);
 
     // Override the correct hash with the wrong one.
     let wrong_hash =
@@ -73,7 +73,7 @@ fn preimage_does_not_match_wrong_address() {
 #[test]
 fn all_zero_preimage_is_valid_and_hashes() {
     let preimage_bytes = vec![0u8; 32];
-    let account = UnspendableAccount::new(&preimage_bytes);
+    let account = UnspendableAccount::from_secret(&preimage_bytes);
     assert!(!account.account_id.to_vec().iter().all(Field::is_zero));
 }
 

--- a/wormhole/tests/test-helpers/src/lib.rs
+++ b/wormhole/tests/test-helpers/src/lib.rs
@@ -29,8 +29,10 @@ impl TestInputs for CircuitInputs {
             .unwrap();
 
         let funding_account = BytesDigest::from(DEFAULT_FUNDING_ACCOUNT);
-        let nullifier = Nullifier::new(&secret, DEFAULT_TRANSFER_COUNT).hash.into();
-        let unspendable_account = UnspendableAccount::new(&secret).account_id.into();
+        let nullifier = Nullifier::from_preimage(&secret, DEFAULT_TRANSFER_COUNT)
+            .hash
+            .into();
+        let unspendable_account = UnspendableAccount::from_secret(&secret).account_id.into();
         let exit_account = BytesDigest::from(DEFAULT_TO_ACCOUNT);
 
         let storage_proof = ProcessedStorageProof::test_inputs();
@@ -129,7 +131,7 @@ pub mod nullifier {
     impl TestInputs for Nullifier {
         fn test_inputs() -> Self {
             let secret = hex::decode(DEFAULT_SECRET).unwrap();
-            Self::new(secret.as_slice(), DEFAULT_TRANSFER_COUNT)
+            Self::from_preimage(secret.as_slice(), DEFAULT_TRANSFER_COUNT)
         }
     }
 }


### PR DESCRIPTION
The nullifier and unspendable account circuit were mistakenly always hashing the preimage and using the result in the circuit - even outside of tests. This PR corrects that behavior by getting the committed digest directly from the circuit inputs.