### PR TITLE
Generate proof from .bin files

### DIFF
--- a/wormhole/circuit-builder/src/main.rs
+++ b/wormhole/circuit-builder/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::fs::{create_dir_all, write};
 
+use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::PoseidonGoldilocksConfig;
 use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
 use wormhole_circuit::circuit::circuit_logic::WormholeCircuit;
@@ -8,7 +9,8 @@ use zk_circuits_common::circuit::D;
 
 fn main() -> Result<()> {
     println!("Building wormhole circuit...");
-    let circuit = WormholeCircuit::default();
+    let config = CircuitConfig::standard_recursion_config();
+    let circuit = WormholeCircuit::new(config);
     let circuit_data = circuit.build_circuit();
     println!("Circuit built.");
 

--- a/wormhole/tests/Cargo.toml
+++ b/wormhole/tests/Cargo.toml
@@ -16,7 +16,7 @@ wormhole-circuit = { path = "../circuit", default-features = true }
 wormhole-prover = { path = "../prover", default-features = true }
 wormhole-verifier = { path = "../verifier", default-features = true }
 test-helpers = { path = "./test-helpers" }
-plonky2 = { workspace = true, features = ["std"] }
+plonky2 = { workspace = true, default-features = true }
 anyhow = { workspace = true }
 hex = { workspace = true }
 rand = { version = "0.9.1", default-features = false, features = [

--- a/wormhole/tests/src/prover/prover_tests.rs
+++ b/wormhole/tests/src/prover/prover_tests.rs
@@ -76,3 +76,26 @@ fn export_hex_proof_for_pallet() {
     let hex_proof = hex::encode(proof_bytes);
     let _ = fs::write(FILE_PATH, hex_proof);
 }
+
+#[test]
+#[ignore = "debug"]
+fn export_hex_proof_from_bins_for_pallet() {
+    const FILE_PATH: &str = "proof_from_bins.hex";
+
+    // Use the pre-generated bin files to ensure compatibility with the verifier
+    let prover = WormholeProver::new_from_files(
+        std::path::Path::new("../../generated-bins/prover.bin"),
+        std::path::Path::new("../../generated-bins/common.bin"),
+    )
+    .expect("Failed to load prover from bin files");
+
+    let inputs = CircuitInputs::test_inputs();
+    let proof = prover.commit(&inputs).unwrap().prove().unwrap();
+    let proof_bytes = proof.to_bytes();
+    let proof_size = proof_bytes.len();
+    let hex_proof = hex::encode(proof_bytes);
+    let _ = fs::write(FILE_PATH, hex_proof);
+
+    println!("Generated proof hex file: {}", FILE_PATH);
+    println!("Proof size: {} bytes", proof_size);
+}


### PR DESCRIPTION
This is needed to test on the chain, so we use the same verifier bin